### PR TITLE
add avli error handling and firefox profile creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,22 @@ You can customize the prompt segment behavior by overriding these variables:
 |--------------------------------|---------|-----------------------------------------------------------------------------|
 | `AWS_VAULT_PL_CHAR`            | ☁       | The character to display when logged into an aws-vault profile              |
 | `AWS_VAULT_PL_DEFAULT_PROFILE` | default | Only show the character when logged into this profile, not the profile name |
+
+### avli - login in private browsing window
+
+> This alias is currently only supported in OSX.
+
+This alias will open a new browser window after getting the temporary login URL for your profile.
+
+You can specify a specific browser to handle your login URL by setting `AWS_VAULT_PL_BROWSER` to the bundle name of the
+browser. By default, it will pick your default URL handler in the OS.
+
+#### Firefox (`org.mozilla.firefox`)
+
+When Firefox is detected, the command will create a new profile with the same name as your aws-vault profile, and open the
+session in that profile. This allows for multiple profiles to be open simultaneously.
+
+#### Chrome (`com.google.chrome`)
+
+When Chrome is detected, the command will open a new private browsing window with the session. This does not (currently)
+allow for multiple profiles to be open simultaneously.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # zsh-aws-vault
+
 oh-my-zsh plugin for [aws-vault](https://github.com/99designs/aws-vault)
 
 ## Installation
@@ -27,8 +28,9 @@ This plugin is intended to be used with oh-my-zsh
 ## Features
 
 This plugin is pretty simple - it provides:
-  - aliases
-  - prompt segment
+
+- aliases
+- prompt segment
 
 ### Aliases
 
@@ -50,6 +52,7 @@ I use this for adding a segment into my custom
 [agnoster theme](https://github.com/agnoster/agnoster-zsh-theme/blob/master/agnoster.zsh-theme).
 
 For instance, this code:
+
 ```bash
 prompt_aws_vault() {
   local vault_segment
@@ -63,6 +66,7 @@ Produces this segment in my prompt:
 ![screenshot of agnoster theme with aws-vault segment](https://i.imgur.com/BLE0QXg.png)
 
 #### Prompt Customization
+
 You can customize the prompt segment behavior by overriding these variables:
 
 | Variable Name                  | Default | Description                                                                 |
@@ -77,14 +81,9 @@ You can customize the prompt segment behavior by overriding these variables:
 This alias will open a new browser window after getting the temporary login URL for your profile.
 
 You can specify a specific browser to handle your login URL by setting `AWS_VAULT_PL_BROWSER` to the bundle name of the
-browser. By default, it will pick your default URL handler in the OS.
+browser. By default, it will pick your default URL handler in MacOS. It supports the following browsers:
 
-#### Firefox (`org.mozilla.firefox`)
-
-When Firefox is detected, the command will create a new profile with the same name as your aws-vault profile, and open the
-session in that profile. This allows for multiple profiles to be open simultaneously.
-
-#### Chrome (`com.google.chrome`)
-
-When Chrome is detected, the command will open a new private browsing window with the session. This does not (currently)
-allow for multiple profiles to be open simultaneously.
+| `AWS_VAULT_PL_BROWSER` value | Browser | Description                                                                 |
+|------------------------------|---------|-----------------------------------------------------------------------------|
+| `org.mozilla.firefox`        | Firefox | Creates and/or opens a profile with the same name as your aws-vault profile This allows for multiple profiles to be open simultaneously. |
+| `com.google.chrome`          | Chrome  | Opens a new private browsing window for the session. This does not (currently) allow for multiple profiles to be open simultaneously. |

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -93,15 +93,16 @@ function _using_osx() {
 
 function _find_browser() {
   if [ -n "$AWS_VAULT_PL_BROWSER" ]; then
+    # use the browser bundle specified
     echo "$AWS_VAULT_PL_BROWSER"
-  fi
-  if _using_osx ; then
+  elif _using_osx ; then
+    # Detect the browser in launchservices
     # https://stackoverflow.com/a/32465364/808678
     local prefs=~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist
     plutil -convert xml1 $prefs
     grep 'https' -b3 $prefs | awk 'NR==2 {split($2, arr, "[><]"); print arr[3]}';
     plutil -convert binary1 $prefs
   else
-    # TODO
+    # TODO - other platforms
   fi
 }

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -3,6 +3,7 @@
 #--------------------------------------------------------------------#
 AWS_VAULT_PL_DEFAULT_PROFILE=${AWS_VAULT_PL_DEFAULT_PROFILE:-default}
 AWS_VAULT_PL_CHAR=${AWS_VAULT_PL_CHAR:-$'\u2601'} # "the cloud"
+AWS_VAULT_PL_BROWSER=${AWS_VAULT_PL_BROWSER:-''}
 
 #--------------------------------------------------------------------#
 # Aliases                                                            #
@@ -21,14 +22,22 @@ function avsh() {
 }
 
 function avli() {
-  local login_url="$(avll $1)"
+  local login_url
+  login_url="$(avll $1)"
+
+  if [ $? -ne 0 ]; then
+    echo "could not login"
+    return
+  fi
 
   if _using_osx ; then
     local browser="$(_find_browser)"
 
     case $browser in
       org.mozilla.firefox)
-        echo "${login_url}" | xargs /Applications/Firefox.app/Contents/MacOS/firefox --private-window
+        # Ensure a profile is created (can run idempotently) and launch it as a disowned process
+        /Applications/Firefox.app/Contents/MacOS/firefox --CreateProfile $1 2>/dev/null && \
+        /Applications/Firefox.app/Contents/MacOS/firefox --no-remote -P $1 "${login_url}" 2>/dev/null &!
         ;;
       com.google.chrome)
         echo "${login_url}" | xargs /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --incognito --new-window
@@ -83,6 +92,9 @@ function _using_osx() {
 }
 
 function _find_browser() {
+  if [ -n "$AWS_VAULT_PL_BROWSER" ]; then
+    echo "$AWS_VAULT_PL_BROWSER"
+  fi
   if _using_osx ; then
     # https://stackoverflow.com/a/32465364/808678
     local prefs=~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -26,8 +26,8 @@ function avli() {
   login_url="$(avll $1)"
 
   if [ $? -ne 0 ]; then
-    echo "could not login"
-    return
+    echo "Could not login" >&2
+    return 1
   fi
 
   if _using_osx ; then


### PR DESCRIPTION
This changeset adds some useful functionality to the firefox url handling for the `avli` function. 

1. It now detects if the `avll` command fails (eg, you fat finger your MFA) and exits instead of sending the text of the error as a URL to the browser
1. For Firefox, each av profile will now build a firefox profile, allowing multiple profiles to work simultaneously and avoiding the dreaded 'A copy of Firefox is already open. Only one copy of Firefox can be open at a time.'