### PR TITLE
Multiple AWS console incognito windows 

### DIFF
--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -40,7 +40,7 @@ function avli() {
         /Applications/Firefox.app/Contents/MacOS/firefox --no-remote -P $1 "${login_url}" 2>/dev/null &!
         ;;
       com.google.chrome)
-        echo "${login_url}" | xargs /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --incognito --new-window
+        echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/chrome.XXXXXX) --user-data-dir=$(mktemp -d /tmp/chrome.XXXXXX) > /dev/null 2>&1 &
         ;;
       *)
         # NOTE PRs welcome to add your browser


### PR DESCRIPTION
This change allows for multiple AWS incognito windows to be open, it spawns up a new instance of chrome for every avli command. 