### PR TITLE
Add support for Firefox Developer Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ browser. By default, it will pick your default URL handler in MacOS. It supports
 | `AWS_VAULT_PL_BROWSER` value | Browser | Description                                                                 |
 |------------------------------|---------|-----------------------------------------------------------------------------|
 | `org.mozilla.firefox`        | Firefox | Creates and/or opens a profile with the same name as your aws-vault profile. This allows for multiple profiles to be open simultaneously. |
+| `org.mozilla.firefoxdeveloperedition`  | Firefox Developer Edition | Creates and/or opens a profile with the same name as your aws-vault profile. This allows for multiple profiles to be open simultaneously. |
 | `com.google.chrome`          | Chrome  | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
 | `com.brave.Browser`          | Brave   | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
 

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -62,6 +62,10 @@ function avli() {
         /Applications/Firefox.app/Contents/MacOS/firefox --CreateProfile $1 2>/dev/null && \
         /Applications/Firefox.app/Contents/MacOS/firefox --no-remote -P $1 "${login_url}" 2>/dev/null &!
         ;;
+      org.mozilla.firefoxdeveloperedition)
+        /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox --CreateProfile $1 2>/dev/null && \
+        /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox --no-remote -P $1 "${login_url}" 2>/dev/null &!
+        ;;
       com.google.chrome)
         echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/chrome.XXXXXX) --user-data-dir=$(mktemp -d /tmp/chrome.XXXXXX) > /dev/null 2>&1 &
         ;;


### PR DESCRIPTION
This change adds support for [Firefox Developer Edition](https://www.mozilla.org/en-US/firefox/developer/) on MacOS