### PR TITLE
Adds profiles autocompletion, new aven function, reads AWS_VAULT if profile not specified

### DIFF
--- a/_av_completion
+++ b/_av_completion
@@ -1,0 +1,5 @@
+#compdef avl avll avli aven
+function _av_completion() {
+  _arguments "1: :($(grep '\[profile' ~/.aws/config | sed -n 's/\[profile \(.*\).*\]/\1/p' | sort))"
+}
+_av_completion "$@"

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -11,40 +11,63 @@ AWS_VAULT_PL_MFA=${AWS_VAULT_PL_MFA:-''}
 #--------------------------------------------------------------------#
 alias av='aws-vault'
 alias ave='aws-vault exec'
-alias avl='aws-vault login'
 alias avs='aws-vault server'
-alias avll='avl -s'
 
 #--------------------------------------------------------------------#
 # Convenience Functions                                              #
 #--------------------------------------------------------------------#
+function avl() {
+  local aws_profile=${1:-$AWS_VAULT}
+  aws-vault login $aws_profile
+}
+
+function avll() {
+  local aws_profile=${1:-$AWS_VAULT}
+  aws-vault login -s $aws_profile
+}
+
+function aven() {
+  local aws_profile=${1:-$AWS_VAULT}
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_DEFAULT_REGION
+  unset AWS_REGION
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_SECURITY_TOKEN
+  unset AWS_SESSION_EXPIRATION
+  unset AWS_SESSION_TOKEN
+  unset AWS_VAULT
+  export $(aws-vault exec $aws_profile -- env | grep AWS)
+}
+
 function avsh() {
+  local aws_profile=${1:-$AWS_VAULT}
   case ${AWS_VAULT_PL_MFA} in
     inline)
-      aws-vault exec -t $2 $1 -- zsh
+      aws-vault exec -t $2 $aws_profile -- zsh
       ;;
     yubikey)
       totp=${2:-$1}
-      aws-vault exec -t $(ykman oath code --single $totp) $1 -- zsh
+      aws-vault exec -t $(ykman oath code --single $totp) $aws_profile -- zsh
       ;;
     *)
-      aws-vault exec $1 -- zsh
+      aws-vault exec $aws_profile -- zsh
       ;;
   esac
 }
 
 function avli() {
   local login_url
+  local aws_profile=${1:-$AWS_VAULT}
   case ${AWS_VAULT_PL_MFA} in
     inline)
-      login_url="$(avll -t $2 $1)"
+      login_url="$(avll -t $2 $aws_profile)"
       ;;
     yubikey)
-      totp=${2:-$1}
-      login_url="$(avll -t $(ykman oath code --single $totp) $1)"
+      totp=${2:-$aws_profile}
+      login_url="$(avll -t $(ykman oath code --single $totp) $aws_profile)"
       ;;
     *)
-      login_url="$(avll $1)"
+      login_url="$(avll $aws_profile)"
       ;;
   esac
 


### PR DESCRIPTION
This adds

aven - function performs executes ave and imports AWS tokens to current running shell instead of starting new shell allowing to switching profiles without switching shell

read AWS_VAULT variable when profile not specified - for example after you ran ave and want to fire avli with same profile you dont have to type it, it will take profile name from env var

autocompletion completes with ~/.aws/config profile names commands avl avll avli and so on allowing for faster typing and switches