### PR TITLE
feat: added support for Arc browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ browser. By default, it will pick your default URL handler in MacOS. It supports
 | `com.google.chrome`          | Chrome  | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
 | `com.brave.Browser`          | Brave   | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
 | `com.vivaldi.browser`        | Vivaldi | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
+| `company.thebrowser.browser` | Arc (OSX only) | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously. |
 
 You can pass arbitrary parameters when launching the browser by setting the optional `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS`
 environment variable. For example, if you wanted to start new `avli` browser windows maximized, you can set

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -80,6 +80,9 @@ function avli() {
       com.vivaldi.browser)
         echo "${login_url}" | xargs -t nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) --user-data-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) > /dev/null 2>&1 &
         ;;
+      company.thebrowser.Browser | company.thebrowser.browser | arc) # Arc Browser
+        _open_arc_incog_window "${login_url}" 2>&1 &>/dev/null
+        ;;
       *)
         # NOTE PRs welcome to add your browser
         echo "Sorry, I don't know how to launch your default browser ($browser) :-("
@@ -166,4 +169,16 @@ function _find_browser() {
   else
     # TODO - other platforms
   fi
+}
+
+function _open_arc_incog_window(){
+  url=$1
+  osascript -e "
+    tell application \"Arc\"
+        make new window with properties {incognito:true}
+        activate
+        delay(0.5) # wait for window to open
+        tell front window to make new tab with properties {URL:\"$url\"}
+    end tell
+  "
 }


### PR DESCRIPTION
Added support for Arc browser (only for macos). Since Arc doesn't allow invocation via terminal, used Arc's Apple Script interface. However this means user is not allowed to pass additional configs via `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS` for Arc browser yet. 

Tested locally on:
Version 1.53.0 (52080)
Chromium Engine Version 127.0.6533.73