### PR TITLE
feat: add alias `avr` to refresh credentials within a subshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This plugin is pretty simple - it provides:
 | avs           | aws-vault server                             |
 | [avsh](#avsh) | aws-vault exec $1 -- zsh                     |
 | avp           | list aws config / role ARNs                  |
+| avr           | eval $(AWS_VAULT=  aws-vault export --format=export-env $AWS_VAULT) |
 
 ### `avli`
 
@@ -81,6 +82,10 @@ For example, place the relevant `AWS` environment variables for your default pro
 ```bash
 avsh default
 ```
+
+### `avr`
+
+Refresh your credentials without exiting the existing subshell. Available when using aws-vault 7+.
 
 ### Prompt Segment
 

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -15,6 +15,7 @@ alias avs='aws-vault server'
 alias avl='aws-vault login'
 alias avll='aws-vault login -s'
 alias ave='aws-vault exec'
+alias avr='eval $(AWS_VAULT=  aws-vault export --format=export-env $AWS_VAULT)'
 
 #--------------------------------------------------------------------#
 # Convenience Functions                                              #


### PR DESCRIPTION
Creates a new alias `avr` to refresh your credentials from within the same subshell. Updated README with new alias explained.

From the back of these two threads on `aws-vault`:
https://github.com/99designs/aws-vault/issues/816
https://github.com/99designs/aws-vault/pull/1135