### PR TITLE
Adding support for persisting a browser profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This alias will create a sandboxed browser profile after getting the temporary l
 allows opening multiple profiles simultaneously in different browser profiles. This differs from using incognito mode,
 which shares the same profile across all incognito windows.
 
+By default, the session profile will be deleted when the browser is closed. In order to persist a profile, you can set an empty variable `AWS_VAULT_PL_PERSIST_PROFILE` which will store the profile in the default path of `~/.aws/avli`. To support browsers that run in a sandbox, a path can be specified such as `AWS_VAULT_PL_PERSIST_PROFILE=~/snap/firefox/common/.mozilla/firefox`. This functionality is currently only supported in Linux.
+
 You can specify a specific browser to handle your login URL by setting `AWS_VAULT_PL_BROWSER` to the bundle name of the
 browser. By default, it will pick your default URL handler in MacOS. It supports the following browsers:
 


### PR DESCRIPTION
This is to allow the ability to refresh a session within the same profile when it is expired and to keep the profiles persistent for each execution of the command.

> ❯ exec zsh

- [x] Regression test `avli` without providing the new parameter. The temp profile should be created in `/tmp` and upon exiting the browser it should be deleted.
  > ❯ avli test
  > ❯ ls /tmp/ | grep avli
  > avli.w46DW5
  > (exit browser)
  > ❯ ls /tmp/ | grep avli

- [x] Include an empty `AWS_VAULT_PL_PERSIST_PROFILE` variable. Profile should be saved in `~/.aws`  and upon exiting the browser it should remain.
  > ❯ AWS_VAULT_PL_PERSIST_PROFILE= avli test
  > ❯ ls ~/.aws/avli/google-chrome | grep test
  > test
  > (exit browser)
  > ❯ ls ~/.aws/avli/google-chrome | grep test
  > test

- [x] Include the `AWS_VAULT_PL_PERSIST_PROFILE` variable and set a path. Profile should be saved in the custom path and upon exiting the browser it should remain.
  > ❯ AWS_VAULT_PL_PERSIST_PROFILE=~/.aws/persist/ avli test
  > ❯ ls ~/.aws/persist/google-chrome | grep test
  > test
  > (exit browser)
  > ❯ ls ~/.aws/persist/google-chrome | grep test
  > test