### PR TITLE
feat: support persisting profiles between `avli` runs (and function refactor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,22 @@ plugins=(
 
 ## Features
 
-This plugin is pretty simple - it provides:
+This plugin provides a comprehensive set of tools for working with aws-vault:
 
-- aliases
-- prompt segment
+- **Aliases** for common aws-vault commands:
 
-### Command
+  - `av` - aws-vault
+  - `avs` - aws-vault server
+  - `avl` - aws-vault login
+  - `avll` - aws-vault login -s (prints the login URL to the screen without opening your browser)
+  - `ave` - aws-vault exec
 
-| Command       | Behavior                                                        |
-| ------------- | --------------------------------------------------------------- |
-| av            | alias - aws-vault                                               |
-| ave           | alias - aws-vault exec                                          |
-| avl           | alias - aws-vault login                                         |
-| avll          | alias - aws-vault login -s                                      |
-| avs           | alias - aws-vault server                                        |
-| [avli](#avli) | aws-vault login in sandboxed browser profile                    |
-| [avsh](#avsh) | Start a new `zsh` with the specified profile                    |
-| avp           | List all AWS profiles                                           |
-| [avr](#avr)   | Refresh the `AWS_*` environment variables in your current shell |
+- **Convenience Functions**:
+
+  - [`avsh`](#avsh) - Open a new shell with AWS credentials
+  - [`avli`](#avli) - Login to AWS console in your default browser with profile isolation
+  - [`avr`](#avr) - Refresh in-context `AWS_*` environment variables
+  - `avp` - List all configured AWS profiles with their types (IAM Keys or Roles)
 
 ### `avli`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ plugins=(
 1. add `zgen load blimmer/zsh-aws-vault` to your '!saved/save' block
 1. `zgen update`
 
+## Upgrading
+
+Some releases might have breaking changes to behaviors. Before upgrading, please review
+[the Releases page](https://github.com/blimmer/zsh-aws-vault/releases) to understand the changes. This package follows
+Semantic Versioning best-practices.
+
+An upgrade guide for major versions is available in [UPGRADING.md](/UPGRADING.md).
+
 ## Features
 
 This plugin provides a comprehensive set of tools for working with aws-vault:

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ oh-my-zsh plugin for [aws-vault](https://github.com/99designs/aws-vault)
 
 This plugin is intended to be used with oh-my-zsh
 
-1. `$ cd ~/.oh-my-zsh/custom/plugins` (you may have to create the folder)
-2. `$ git clone https://github.com/blimmer/zsh-aws-vault.git`
+1. `cd ~/.oh-my-zsh/custom/plugins` (you may have to create the folder)
+2. `git clone https://github.com/blimmer/zsh-aws-vault.git`
 3. In your .zshrc, add `zsh-aws-vault` to your oh-my-zsh plugins:
 
 ```bash
 plugins=(
-  git
-  ruby
   zsh-aws-vault
 )
 ```
@@ -34,23 +32,23 @@ This plugin is pretty simple - it provides:
 
 ### Aliases
 
-| Alias         | Expression                                   |
-| ------------- | -------------------------------------------- |
-| av            | aws-vault                                    |
-| ave           | aws-vault exec                               |
-| avl           | aws-vault login                              |
-| avll          | aws-vault login -s                           |
-| [avli](#avli) | aws-vault login in sandboxed browser profile |
-| avs           | aws-vault server                             |
-| [avsh](#avsh) | aws-vault exec $1 -- zsh                     |
-| avp           | list aws config / role ARNs                  |
-| avr           | eval $(AWS_VAULT=  aws-vault export --format=export-env $AWS_VAULT) |
+| Alias         | Expression                                                         |
+| ------------- | ------------------------------------------------------------------ |
+| av            | aws-vault                                                          |
+| ave           | aws-vault exec                                                     |
+| avl           | aws-vault login                                                    |
+| avll          | aws-vault login -s                                                 |
+| [avli](#avli) | aws-vault login in sandboxed browser profile                       |
+| avs           | aws-vault server                                                   |
+| [avsh](#avsh) | aws-vault exec $1 -- zsh                                           |
+| avp           | list aws config / role ARNs                                        |
+| avr           | eval $(AWS_VAULT= aws-vault export --format=export-env $AWS_VAULT) |
 
 ### `avli`
 
 Login in Private Browsing Window
 
-> This alias is currently only supported in OSX and Linux.
+> This alias is currently only supported in MacOS and Linux.
 
 This alias will create a sandboxed browser profile after getting the temporary login URL for your AWS profile. This
 allows opening multiple profiles simultaneously in different browser profiles. This differs from using incognito mode,

--- a/README.md
+++ b/README.md
@@ -30,60 +30,74 @@ This plugin is pretty simple - it provides:
 - aliases
 - prompt segment
 
-### Aliases
+### Command
 
-| Alias         | Expression                                                         |
-| ------------- | ------------------------------------------------------------------ |
-| av            | aws-vault                                                          |
-| ave           | aws-vault exec                                                     |
-| avl           | aws-vault login                                                    |
-| avll          | aws-vault login -s                                                 |
-| [avli](#avli) | aws-vault login in sandboxed browser profile                       |
-| avs           | aws-vault server                                                   |
-| [avsh](#avsh) | aws-vault exec $1 -- zsh                                           |
-| avp           | list aws config / role ARNs                                        |
-| avr           | eval $(AWS_VAULT= aws-vault export --format=export-env $AWS_VAULT) |
+| Command       | Behavior                                                        |
+| ------------- | --------------------------------------------------------------- |
+| av            | alias - aws-vault                                               |
+| ave           | alias - aws-vault exec                                          |
+| avl           | alias - aws-vault login                                         |
+| avll          | alias - aws-vault login -s                                      |
+| avs           | alias - aws-vault server                                        |
+| [avli](#avli) | aws-vault login in sandboxed browser profile                    |
+| [avsh](#avsh) | Start a new `zsh` with the specified profile                    |
+| avp           | List all AWS profiles                                           |
+| [avr](#avr)   | Refresh the `AWS_*` environment variables in your current shell |
 
 ### `avli`
 
-Login in Private Browsing Window
+Login in an isolated browser profile.
 
-> This alias is currently only supported in MacOS and Linux.
+> ℹ️ This function is currently only supported in MacOS and Linux.
 
-This alias will create a sandboxed browser profile after getting the temporary login URL for your AWS profile. This
+This function will create a sandboxed browser profile after getting the temporary login URL for your AWS profile. This
 allows opening multiple profiles simultaneously in different browser profiles. This differs from using incognito mode,
 which shares the same profile across all incognito windows.
 
-You can specify a specific browser to handle your login URL by setting `AWS_VAULT_PL_BROWSER` to the bundle name of the
-browser. By default, it will pick your default URL handler in MacOS. It supports the following browsers:
+#### Specifying a Browser
 
-| `AWS_VAULT_PL_BROWSER` value          | Browser                   |
-| ------------------------------------- | ------------------------- |
-| `org.mozilla.firefox`                 | Firefox                   |
-| `org.mozilla.firefoxdeveloperedition` | Firefox Developer Edition |
-| `com.google.chrome`                   | Chrome                    |
-| `com.microsoft.edgemac`               | Edge                      |
-| `com.microsoft.edgemac.dev`           | Edge Developer Edition    |
-| `com.brave.Browser`                   | Brave                     |
-| `com.vivaldi.browser`                 | Vivaldi                   |
+You can specify a browser to use for `avli` by setting the `AWS_VAULT_PL_BROWSER` environment variable to the appropriate
+browser.
 
-You can pass arbitrary parameters when launching the browser by setting the optional `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS`
+In MacOS, we use the default browser set at the system level. On Linux, we use `xdg-settings` to find the default.
+
+| Browser                   | `AWS_VAULT_PL_BROWSER` value (MacOS)  | `AWS_VAULT_PL_BROWSER` value (Linux) |
+| ------------------------- | ------------------------------------- | ------------------------------------ |
+| Firefox                   | `org.mozilla.firefox`                 |                                      |
+| Firefox Developer Edition | `org.mozilla.firefoxdeveloperedition` |                                      |
+| Chrome                    | `com.google.chrome`                   |                                      |
+| Edge                      | `com.microsoft.edgemac`               |                                      |
+| Edge Developer Edition    | `com.microsoft.edgemac.dev`           |                                      |
+| Brave                     | `com.brave.Browser`                   |                                      |
+| Vivaldi                   | `com.vivaldi.browser`                 |                                      |
+
+#### Passing Additional Browser Launch Options
+
+You can pass arbitrary parameters when launching your browser by setting the optional `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS`
 environment variable. For example, if you wanted to start new `avli` browser windows maximized, you can set
 `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS="--start-maximized"`. Refer to your browser documentation for possible options.
 
+#### Reusing Sandboxed Profiles
+
+By default, each time you run `avli`, a new, isolated browser profile is created. If you would like to reuse the same
+browser profile between calls to `avli`, set the `AWS_VAULT_PL_PERSIST_PROFILE` environment variable to `true`.
+
+This allows you to install extensions/addons, create bookmarks, retain history, etc. in the sandboxed browser.
+
 ### `avsh`
 
-Create a shell for a given profile.
-
-For example, place the relevant `AWS` environment variables for your default profile by running:
+Create a shell for a given profile. For example, this command replaces the relevant `AWS_*` environment variables for
+the `default` profile in a new shell session:
 
 ```bash
 avsh default
 ```
 
+This is a powerful tool that allows only placing AWS credentials in your shell session when needed.
+
 ### `avr`
 
-Refresh your credentials without exiting the existing subshell. Available when using aws-vault 7+.
+Refresh your credentials without exiting the existing subshell. Requires `aws-vault` v7 or newer.
 
 ### Prompt Segment
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,20 @@ which shares the same profile across all incognito windows.
 You can specify a browser to use for `avli` by setting the `AWS_VAULT_PL_BROWSER` environment variable to the appropriate
 browser.
 
-In MacOS, we use the default browser set at the system level. On Linux, we use `xdg-settings` to find the default.
+In MacOS, we use the default browser set at the system level. You can override using these values:
 
-| Browser                   | `AWS_VAULT_PL_BROWSER` value (MacOS)  | `AWS_VAULT_PL_BROWSER` value (Linux) |
-| ------------------------- | ------------------------------------- | ------------------------------------ |
-| Firefox                   | `org.mozilla.firefox`                 |                                      |
-| Firefox Developer Edition | `org.mozilla.firefoxdeveloperedition` |                                      |
-| Chrome                    | `com.google.chrome`                   |                                      |
-| Edge                      | `com.microsoft.edgemac`               |                                      |
-| Edge Developer Edition    | `com.microsoft.edgemac.dev`           |                                      |
-| Brave                     | `com.brave.Browser`                   |                                      |
-| Vivaldi                   | `com.vivaldi.browser`                 |                                      |
+| Browser                   | `AWS_VAULT_PL_BROWSER` value (MacOS)  |
+| ------------------------- | ------------------------------------- |
+| Firefox                   | `org.mozilla.firefox`                 |
+| Firefox Developer Edition | `org.mozilla.firefoxdeveloperedition` |
+| Chrome                    | `com.google.chrome`                   |
+| Edge                      | `com.microsoft.edgemac`               |
+| Edge Developer Edition    | `com.microsoft.edgemac.dev`           |
+| Brave                     | `com.brave.Browser`                   |
+| Vivaldi                   | `com.vivaldi.browser`                 |
+
+On Linux, we use `xdg-settings` to find the default. You can set the `AWS_VAULT_PL_BROWSER` environment variable to
+your browser's binary (e.g., `chromium` or `/usr/bin/chromium`).
 
 #### Passing Additional Browser Launch Options
 
@@ -89,6 +92,10 @@ By default, each time you run `avli`, a new, isolated browser profile is created
 browser profile between calls to `avli`, set the `AWS_VAULT_PL_PERSIST_PROFILE` environment variable to `true`.
 
 This allows you to install extensions/addons, create bookmarks, retain history, etc. in the sandboxed browser.
+
+By default, the profiles are stored in `~/.config/zsh-aws-vault/avli-profiles/<browser-name>/<profile-name>`. You can
+customize the path portion of this (`~/.config/zsh-aws-vault/avli-profiles`) by setting the
+`AWS_VAULT_PL_PERSIST_PROFILE_PATH` environment variable.
 
 ### `avsh`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,21 @@
+# Upgrading
+
+## Pre-1.0 to 1.0
+
+Release 1.0 contains a large rewrite of the `avli` command, which may cause breaking changes if you relied on existing,
+inconsistent behavior.
+
+### Breaking Changes
+
+- By default, `avli` calls on Linux and Mac now remove the temporary profile directory when the browser closes. If you
+  want to retain the profile between calls to `avli`, set the `AWS_VAULT_PL_PERSIST_PROFILE` environment variable to
+  `true`.
+- `avli` calls launching MacOS Firefox now creates profiles in the `/tmp` directory by default, instead of in the
+  ApplicationSupport directory, as before. This means that, by default, Firefox `avli` profiles are completely transient
+  by default. If you'd like to retain your browser profile between launches, set the `AWS_VAULT_PL_PERSIST_PROFILE`
+  environment variable to `true`.
+- `avli` calls use `nohup` to ensure the browser is not terminated if the terminal window that launched it is closed.
+- Utility functions `_using_osx()`, `_using_linux()`, and `_find_browser()` are no longer exported to your ZSH
+  environment. These utility functions are internal and should not have been exposed in your ZSH environment. If you
+  relied on having these functions available, view their definitions and export the functions manually from your
+  `~/.zshrc` file.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,6 +14,8 @@ inconsistent behavior.
   ApplicationSupport directory, as before. This means that, by default, Firefox `avli` profiles are completely transient
   by default. If you'd like to retain your browser profile between launches, set the `AWS_VAULT_PL_PERSIST_PROFILE`
   environment variable to `true`.
+- `avli` calls using Chrome (and chrome-like browsers) no longer pass the `--new-window` flag by default. To retain the
+  existing behavior, set the `AWS_VAULT_PL_BROWSER_LAUNCH_OPTS` to include `--new-window`.
 - `avli` calls use `nohup` to ensure the browser is not terminated if the terminal window that launched it is closed.
 - Utility functions `_using_osx()`, `_using_linux()`, and `_find_browser()` are no longer exported to your ZSH
   environment. These utility functions are internal and should not have been exposed in your ZSH environment. If you

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -73,6 +73,7 @@ function avli() {
 
     if [ "$AWS_VAULT_PL_PERSIST_PROFILE" = "true" ]; then
       browser_profile_path="${AWS_VAULT_PL_PERSIST_PROFILE_PATH}/${browser}/${profile}"
+      mkdir -p "${AWS_VAULT_PL_PERSIST_PROFILE_PATH}/${browser}"
     else
       browser_profile_path=$(mktemp --tmpdir -d $browser.$profile.XXXXXX)
     fi
@@ -113,7 +114,6 @@ function avli() {
 
   if _using_osx ; then
     local browser_profile_path=$(_get_browser_profile_path $browser $1)
-    mkdir -p $browser_profile_path
     case $browser in
       # TODO: this doesn't seem to work on MacOS Firefox - I think the profile needs to be in the "expected" location, as we were doing before...
       # I need to dig more into this.

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -64,6 +64,10 @@ function avli() {
     fi
   }
 
+  function _chromium_common_flags() {
+    echo "--no-first-run --new-window"
+  }
+
   local login_url
   case ${AWS_VAULT_PL_MFA} in
     inline)
@@ -96,19 +100,19 @@ function avli() {
         /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote -P $1 "${login_url}" 2>/dev/null &!
         ;;
       com.google.chrome)
-        echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/chrome.XXXXXX) --user-data-dir=$(mktemp -d /tmp/chrome.XXXXXX) > /dev/null 2>&1 &
+        echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir=$(mktemp -d /tmp/chrome.XXXXXX) --user-data-dir=$(mktemp -d /tmp/chrome.XXXXXX) > /dev/null 2>&1 &
         ;;
       com.microsoft.edgemac)
-        echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/msedge.XXXXXX) --user-data-dir=$(mktemp -d /tmp/msedge.XXXXXX) > /dev/null 2>&1 &
+        echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir=$(mktemp -d /tmp/msedge.XXXXXX) --user-data-dir=$(mktemp -d /tmp/msedge.XXXXXX) > /dev/null 2>&1 &
         ;;
       com.microsoft.edgemac.dev)
-        echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/msedgedev.XXXXXX) --user-data-dir=$(mktemp -d /tmp/msedgedev.XXXXXX) > /dev/null 2>&1 &
+        echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir=$(mktemp -d /tmp/msedgedev.XXXXXX) --user-data-dir=$(mktemp -d /tmp/msedgedev.XXXXXX) > /dev/null 2>&1 &
         ;;
       com.brave.Browser|com.brave.browser)
-        echo "${login_url}" | xargs -t nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/brave.XXXXXX) --user-data-dir=$(mktemp -d /tmp/brave.XXXXXX) > /dev/null 2>&1 &
+        echo "${login_url}" | xargs -t nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir=$(mktemp -d /tmp/brave.XXXXXX) --user-data-dir=$(mktemp -d /tmp/brave.XXXXXX) > /dev/null 2>&1 &
         ;;
       com.vivaldi.browser)
-        echo "${login_url}" | xargs -t nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) --user-data-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) > /dev/null 2>&1 &
+        echo "${login_url}" | xargs -t nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) --user-data-dir=$(mktemp -d /tmp/vivaldi.XXXXXX) > /dev/null 2>&1 &
         ;;
       *)
         # NOTE PRs welcome to add your browser
@@ -119,7 +123,7 @@ function avli() {
     AVLI_TMP_PROFILE=$(mktemp --tmpdir -d avli.XXXXXX)
     case $browser in
       *"chrom"*|*"brave"*|*"vivaldi"*)
-        (${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --new-window --disk-cache-dir="${AVLI_TMP_PROFILE}" --user-data-dir="${AVLI_TMP_PROFILE}" "${login_url}" 2>/dev/null && rm -rf "${AVLI_TMP_PROFILE}") &!
+        (${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${AVLI_TMP_PROFILE}" --user-data-dir="${AVLI_TMP_PROFILE}" "${login_url}" 2>/dev/null && rm -rf "${AVLI_TMP_PROFILE}") &!
         ;;
       *"firefox"*)
         (${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS -profile "${AVLI_TMP_PROFILE}" -no-remote -new-instance "${login_url}" 2>/dev/null && rm -rf "${AVLI_TMP_PROFILE}") &!

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -163,13 +163,13 @@ function avli() {
     case $browser in
       *"chrom"*|*"brave"*|*"vivaldi"*)
         (
-          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" 2>/dev/null
+          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
       *"firefox"*)
         (
-          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS -profile "${browser_profile_path}" -no-remote -new-instance "${login_url}" 2>/dev/null
+          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --profile "${browser_profile_path}" --no-remote --new-instance "${login_url}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -118,12 +118,12 @@ function avli() {
       # TODO: this doesn't seem to work on MacOS Firefox - I think the profile needs to be in the "expected" location, as we were doing before...
       # I need to dig more into this.
       org.mozilla.firefox)
-        /Applications/Firefox.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote -P $browser_profile_path $login_url 2>/dev/null && \
-        _maybe_clean_up_browser_profile "${browser_profile_path}" &!
+        (/Applications/Firefox.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url 2>/dev/null && \
+        _maybe_clean_up_browser_profile "${browser_profile_path}") &!
         ;;
       org.mozilla.firefoxdeveloperedition)
-        /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote -P $browser_profile_path $login_url 2>/dev/null && \
-          _maybe_clean_up_browser_profile "${browser_profile_path}" &!
+        (/Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url 2>/dev/null && \
+          _maybe_clean_up_browser_profile "${browser_profile_path}") &!
         ;;
       com.google.chrome)
         (echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -88,10 +88,6 @@ function avli() {
     fi
   }
 
-  function _chromium_common_flags() {
-    echo "--no-first-run --new-window"
-  }
-
   local login_url
   case ${AWS_VAULT_PL_MFA} in
     inline)
@@ -129,31 +125,31 @@ function avli() {
         ;;
       com.google.chrome)
         (
-          nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
       com.microsoft.edgemac)
         (
-          nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
       com.microsoft.edgemac.dev)
         (
-          nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
       com.brave.Browser|com.brave.browser)
         (
-          nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
       com.vivaldi.browser)
         (
-          nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;
@@ -167,7 +163,7 @@ function avli() {
     case $browser in
       *"chrom"*|*"brave"*|*"vivaldi"*)
         (
-          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" 2>/dev/null
+          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-first-run --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" 2>/dev/null
           _maybe_clean_up_browser_profile "${browser_profile_path}"
         ) &!
         ;;

--- a/zsh-aws-vault.plugin.zsh
+++ b/zsh-aws-vault.plugin.zsh
@@ -115,30 +115,47 @@ function avli() {
   if _using_osx ; then
     local browser_profile_path=$(_get_browser_profile_path $browser $1)
     case $browser in
-      # TODO: this doesn't seem to work on MacOS Firefox - I think the profile needs to be in the "expected" location, as we were doing before...
-      # I need to dig more into this.
       org.mozilla.firefox)
-        (/Applications/Firefox.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url 2>/dev/null && \
-        _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Firefox.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       org.mozilla.firefoxdeveloperedition)
-        (/Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url 2>/dev/null && \
-          _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS --no-remote --profile $browser_profile_path $login_url > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       com.google.chrome)
-        (echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       com.microsoft.edgemac)
-        (echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       com.microsoft.edgemac.dev)
-        (echo "${login_url}" | xargs -t nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Microsoft\ Edge\ Dev.app/Contents/MacOS/Microsoft\ Edge\ Dev "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       com.brave.Browser|com.brave.browser)
-        (echo "${login_url}" | xargs -t nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       com.vivaldi.browser)
-        (echo "${login_url}" | xargs -t nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi %U $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1 && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup /Applications/Vivaldi.app/Contents/MacOS/Vivaldi "${login_url}" $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" > /dev/null 2>&1
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       *)
         # NOTE PRs welcome to add your browser
@@ -149,10 +166,16 @@ function avli() {
     local browser_profile_path=$(_get_browser_profile_path $browser $1)
     case $browser in
       *"chrom"*|*"brave"*|*"vivaldi"*)
-        (${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" 2>/dev/null && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS $(_chromium_common_flags) --disk-cache-dir="${browser_profile_path}" --user-data-dir="${browser_profile_path}" "${login_url}" 2>/dev/null
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       *"firefox"*)
-        (${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS -profile "${browser_profile_path}" -no-remote -new-instance "${login_url}" 2>/dev/null && _maybe_clean_up_browser_profile "${browser_profile_path}") &!
+        (
+          nohup ${browser} $AWS_VAULT_PL_BROWSER_LAUNCH_OPTS -profile "${browser_profile_path}" -no-remote -new-instance "${login_url}" 2>/dev/null
+          _maybe_clean_up_browser_profile "${browser_profile_path}"
+        ) &!
         ;;
       *)
         rm -rf $browser_profile_path


### PR DESCRIPTION
## Background

This PR provides an alternate implementation to #40.

The code for `avli` has grown over time and was inconsistent between browser and platform. The goal of this PR is to standardize the behavior while implementing the new feature.

## TODO

- [x] Figure out what to do with Firefox on MacOS. Can we create a new profile in an alternate location? Or does it have to be created by `--CreateProfile`, as we were doing before?
- [x] Test all supported browsers on Linux
- [x] Test all supported browsers on MacOS
- [x] Update README

## Related Issues

Fixes #41
Fixes #42 